### PR TITLE
Implement support for debugging ILC running over a runtime test

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
 		"onDebugResolve:rt-cg2rt",
 		"onDebugDynamicConfigurations:rt-cg2rt",
 		"onDebugResolve:rt-libsnative",
-		"onDebugDynamicConfigurations:rt-libsnative"
+		"onDebugDynamicConfigurations:rt-libsnative",
+		"onDebugResolve:rt-ilc",
+		"onDebugDynamicConfigurations:rt-ilc"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
@@ -199,6 +201,50 @@
 						"body": {
 							"name": "Launch Crossgen2 against a runtime test",
 							"type": "rt-cg2rt",
+							"request": "launch"
+						}
+					}
+				]
+			},
+			{
+				"type": "rt-ilc",
+				"label": "Debug running ILC on a runtime test",
+				"configurationAttributes": {
+					"launch": {
+						"properties": {
+							"args": {
+								"description": "Program arguments.",
+								"type": [
+									"array",
+									"string"
+								],
+								"default": []
+							},
+							"env": {
+								"type": "object",
+								"additionalProperties": {
+									"type": "string"
+								},
+								"description": "Environment variables to set for the target process"
+							},
+							"cwd": {
+								"type": "string",
+								"description": "The working directory for the target process"
+							},
+							"stopAtEntry": {
+								"type": "boolean",
+								"description": "true if the debugger should break as soon as the process is started."
+							}
+						}
+					}
+				},
+				"configurationSnippets": [
+					{
+						"label": "DN/RT-Assistant: Launch ILC against a runtime test",
+						"description": "A new configuration for running ILC to generate native code for a runtime test.",
+						"body": {
+							"name": "Launch ILC against a runtime test",
+							"type": "rt-ilc",
 							"request": "launch"
 						}
 					}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,9 +2,39 @@ import * as vscode from 'vscode';
 import * as runtimeTestProvider from './providers/runtimetest';
 import * as crossgen2CoreLibTestProvider from './providers/crossgen2-corelib';
 import * as crossgen2TestProvider from './providers/crossgen2';
+import * as ilcTestProvider from './providers/ilc';
 import * as libsNativeTestProvider from './providers/libs-native';
 import { setServerPathFromExtensionContext, getOrStartServerConnection, disconnectServer } from './server';
 import { configureRunSettingsFileForTestRun, importSettingsFromDevContainer } from './commands';
+
+type CustomDebugConfigurationProvider = vscode.DebugConfigurationProvider & {
+	DEBUG_CONFIGURATION_TYPE: string;
+};
+
+type Disposable = { dispose: () => {} };
+
+class CompositeDisposable {
+	private disposables: Disposable[];
+
+	constructor() {
+		this.disposables = new Array<Disposable>();
+	}
+
+	public push(disposable: Disposable) {
+		this.disposables.push(disposable);
+	}
+
+	public dispose() {
+		this.disposables.forEach(disposable => disposable.dispose());
+	}
+}
+
+function registerDebugConfigurationProvider(provider: CustomDebugConfigurationProvider) {
+	const disposables = new CompositeDisposable();
+	disposables.push(vscode.debug.registerDebugConfigurationProvider(provider.DEBUG_CONFIGURATION_TYPE, provider, vscode.DebugConfigurationProviderTriggerKind.Dynamic));
+	disposables.push(vscode.debug.registerDebugConfigurationProvider(provider.DEBUG_CONFIGURATION_TYPE, provider));
+	return disposables;
+}
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -14,14 +44,12 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('dotnet-runtime-test-assistant.importSettingsFromDevContainer', importSettingsFromDevContainer));
 	context.subscriptions.push(vscode.commands.registerCommand('dotnet-runtime-test-assistant.configureRunSettingsFileForTestRun', configureRunSettingsFileForTestRun));
 
-	context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(runtimeTestProvider.DEBUG_CONFIGURATION_TYPE, runtimeTestProvider, vscode.DebugConfigurationProviderTriggerKind.Dynamic));
-	context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(runtimeTestProvider.DEBUG_CONFIGURATION_TYPE, runtimeTestProvider));
-	context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(crossgen2CoreLibTestProvider.DEBUG_CONFIGURATION_TYPE, crossgen2CoreLibTestProvider, vscode.DebugConfigurationProviderTriggerKind.Dynamic));
-	context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(crossgen2CoreLibTestProvider.DEBUG_CONFIGURATION_TYPE, crossgen2CoreLibTestProvider));
-	context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(crossgen2TestProvider.DEBUG_CONFIGURATION_TYPE, crossgen2TestProvider, vscode.DebugConfigurationProviderTriggerKind.Dynamic));
-	context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(crossgen2TestProvider.DEBUG_CONFIGURATION_TYPE, crossgen2TestProvider));
-	context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(libsNativeTestProvider.DEBUG_CONFIGURATION_TYPE, libsNativeTestProvider, vscode.DebugConfigurationProviderTriggerKind.Dynamic));
-	context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(libsNativeTestProvider.DEBUG_CONFIGURATION_TYPE, libsNativeTestProvider));
+	context.subscriptions.push(registerDebugConfigurationProvider(runtimeTestProvider));
+	context.subscriptions.push(registerDebugConfigurationProvider(crossgen2CoreLibTestProvider));
+	context.subscriptions.push(registerDebugConfigurationProvider(crossgen2TestProvider));
+	context.subscriptions.push(registerDebugConfigurationProvider(ilcTestProvider));
+	context.subscriptions.push(registerDebugConfigurationProvider(libsNativeTestProvider));
+	context.subscriptions.push({ dispose: disconnectServer });
 
 	setServerPathFromExtensionContext(context);
 }

--- a/src/providers/ilc.ts
+++ b/src/providers/ilc.ts
@@ -1,0 +1,69 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as userPrompts from '../userPrompts';
+import { DebugConfigurationBase, getCoreClrOutputRootPath, getRuntimeTestArtifactsPath } from '../helpers';
+import { copyFile, writeFile, mkdir } from 'fs/promises';
+import { OutputConfiguration } from '../outputConfiguration';
+import { generateIlcResponseFile } from '../server';
+
+type DebugConfigurationType = 'rt-ilc';
+
+export const DEBUG_CONFIGURATION_TYPE: DebugConfigurationType = 'rt-ilc';
+
+interface IlcConfiguration extends DebugConfigurationBase {
+    type: DebugConfigurationType;
+}
+
+function isIlcConfiguration(debugConfiguration: vscode.DebugConfiguration): debugConfiguration is IlcConfiguration {
+    return debugConfiguration.type === DEBUG_CONFIGURATION_TYPE;
+}
+
+export function transformConfig(debugConfiguration: IlcConfiguration, ilcBuildCoreClrBin: string, responseFilePath: string, ...extraArgs: string[]) {
+    return {
+        name: debugConfiguration.name,
+        type: 'coreclr',
+        request: 'launch',
+        program: path.join(ilcBuildCoreClrBin, 'ilc', 'ilc.dll'),
+        args: [
+            `@${responseFilePath}`,
+            ...extraArgs
+        ]
+    };
+}
+
+export function provideDebugConfigurations(_folder: vscode.WorkspaceFolder | undefined, _token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration[]> {
+    return [
+        {
+            type: DEBUG_CONFIGURATION_TYPE,
+            request: 'launch',
+            name: 'Crossgen2 on Runtime Test',
+            args: [],
+            env: {},
+            stopAtEntry: false
+        }
+    ];
+}
+
+export async function resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, _token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration | undefined> {
+    if (isIlcConfiguration(debugConfiguration)) {
+        if (!folder) {
+            return undefined;
+        }
+        let runtimeTest = await userPrompts.promptUserForRuntimeTestProject({ workspace: folder.uri });
+
+        if (!runtimeTest) {
+            return undefined;
+        }
+
+        let testConfig = await userPrompts.promptUserForTargetConfiguration({ promptPrefix: 'Runtime Test', showChecked: true, defaultConfiguration: 'Debug' });
+
+        if (!testConfig) {
+            return undefined;
+        }
+
+        const rspFile = await generateIlcResponseFile(path.join(folder.uri.fsPath, 'src', 'tests', runtimeTest), testConfig);
+
+        return transformConfig(debugConfiguration, getCoreClrOutputRootPath(folder.uri, testConfig), rspFile, ...(debugConfiguration.args || []));
+    }
+    return debugConfiguration;
+}

--- a/src/providers/ilc.ts
+++ b/src/providers/ilc.ts
@@ -63,6 +63,11 @@ export async function resolveDebugConfiguration(folder: vscode.WorkspaceFolder |
 
         const rspFile = await generateIlcResponseFile(path.join(folder.uri.fsPath, 'src', 'tests', runtimeTest), testConfig);
 
+        if (rspFile === null) {
+            vscode.window.showErrorMessage('Unable to generate ILC response file');
+            return undefined;
+        }
+
         return transformConfig(debugConfiguration, getCoreClrOutputRootPath(folder.uri, testConfig), rspFile, ...(debugConfiguration.args || []));
     }
     return debugConfiguration;

--- a/src/server.ts
+++ b/src/server.ts
@@ -103,3 +103,15 @@ export async function tryCreateVsCodeRunSettings(preTestProjectPath: string, con
     const serverConnection = await getOrStartServerConnection();
     return await serverConnection.sendRequest(TryCreateVsCodeRunSettings.type, preTestProjectPath, configuration.os, configuration.arch, configuration.configuration);
 }
+
+namespace GenerateIlcResponseFile {
+    export const method = 'GenerateIlcResponseFile';
+
+    export const type = new RequestType4<string, string, string, string, string, void>(method);
+}
+
+export async function generateIlcResponseFile(runtimeTestProjectPath: string, configuration: OutputConfiguration) {
+    log(`Generating ILC response file for the runtime test '${runtimeTestProjectPath}' with configuration '${configuration.os}.${configuration.arch}.${configuration.configuration}'`);
+    const serverConnection = await getOrStartServerConnection();
+    return await serverConnection.sendRequest(GenerateIlcResponseFile.type, runtimeTestProjectPath, configuration.os, configuration.arch, configuration.configuration);
+}

--- a/src/server/MSBuildRunner.cs
+++ b/src/server/MSBuildRunner.cs
@@ -19,10 +19,20 @@ internal sealed partial class MSBuildRunner : IDisposable
         this.logger = logger;
         projectCollection = new ProjectCollection();
         // Forward the MSBuild logging through our logging mechanism
-        projectCollection.RegisterLogger(new ConsoleLogger(MSBuildLoggerVerbosity.Normal, line => logger.LogMSBuildOutput(line), _ => { }, () => { }));
+        projectCollection.RegisterLogger(
+            new ConsoleLogger(
+                MSBuildLoggerVerbosity.Normal,
+                line =>
+                    logger.LogMSBuildOutput(line),
+                    _ => { },
+                    () => { }));
+        var binlogPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Temp", "dnrt-assistant", $"{Environment.ProcessId}.binlog");
+        BinaryLogger binaryLog = new() { Parameters = binlogPath, Verbosity = MSBuildLoggerVerbosity.Diagnostic };
+        projectCollection.RegisterLogger(binaryLog);
         buildManager = new BuildManager("AssistantServer");
         buildManager.BeginBuild(new BuildParameters(projectCollection));
         OnDispose += buildManager.EndBuild;
+        OnDispose += binaryLog.Shutdown;
     }
 
     public string[] GetProjectTargetFrameworks(string projectPath)
@@ -59,6 +69,28 @@ internal sealed partial class MSBuildRunner : IDisposable
         var submission = buildManager.BuildRequest(new BuildRequestData(projectInstance, new[] { "GenerateRunSettingsFile" }));
 
         return submission.OverallResult == BuildResultCode.Success;
+    }
+
+    public string? GenerateIlcResponseFile(string testProject, string operatingSystem, string architecture, string configuration)
+    {
+        var projectInstance = buildManager.GetProjectInstanceForBuild(
+            projectCollection.LoadProject(testProject, new Dictionary<string, string>
+            {
+                { "TargetOS", operatingSystem },
+                { "TargetArchitecture", architecture },
+                { "Configuration", configuration },
+                { "TestBuildMode", "nativeaot" },
+                { "IlcDynamicBuildPropertyDependencies", "_ComputeResolvedCopyLocalPublishAssets" }
+            },
+            projectCollection.DefaultToolsVersion));
+        var submission = buildManager.BuildRequest(new BuildRequestData(projectInstance, new[] { "Build", "GetCopyToPublishDirectoryItems", "_ComputeAssembliesToCompileToNative", "WriteIlcRspFileForCompilation" }));
+
+        if (submission.OverallResult != BuildResultCode.Success)
+        {
+            return null;
+        }
+
+        return submission.ResultsByTarget["WriteIlcRspFileForCompilation"].Items[0].ItemSpec;
     }
 
     public void Dispose()

--- a/src/server/MSBuildRunner.cs
+++ b/src/server/MSBuildRunner.cs
@@ -30,8 +30,6 @@ internal sealed partial class MSBuildRunner : IDisposable
         BinaryLogger binaryLog = new() { Parameters = binlogPath, Verbosity = MSBuildLoggerVerbosity.Diagnostic };
         projectCollection.RegisterLogger(binaryLog);
         buildManager = new BuildManager("AssistantServer");
-        buildManager.BeginBuild(new BuildParameters(projectCollection));
-        OnDispose += buildManager.EndBuild;
         OnDispose += binaryLog.Shutdown;
     }
 
@@ -57,40 +55,64 @@ internal sealed partial class MSBuildRunner : IDisposable
 
     public bool TryCreateVsCodeRunSettings(string preTestProject, string operatingSystem, string architecture, string configuration)
     {
-        var projectInstance = buildManager.GetProjectInstanceForBuild(
-            projectCollection.LoadProject(preTestProject, new Dictionary<string, string>
-            {
-                { "TargetOS", operatingSystem },
-                { "TargetArchitecture", architecture },
-                { "Configuration", configuration },
-                { "CreateVsCodeRunSettingsFile", "true" }
-            },
-            projectCollection.DefaultToolsVersion));
-        var submission = buildManager.BuildRequest(new BuildRequestData(projectInstance, new[] { "GenerateRunSettingsFile" }));
+        buildManager.BeginBuild(new BuildParameters(projectCollection)
+        {
+            LogTaskInputs = true,
+            LogInitialPropertiesAndItems = true
+        });
+        try
+        {
+            var projectInstance = buildManager.GetProjectInstanceForBuild(
+                projectCollection.LoadProject(preTestProject, new Dictionary<string, string>
+                {
+                    { "TargetOS", operatingSystem },
+                    { "TargetArchitecture", architecture },
+                    { "Configuration", configuration },
+                    { "CreateVsCodeRunSettingsFile", "true" }
+                },
+                projectCollection.DefaultToolsVersion));
+            var submission = buildManager.BuildRequest(new BuildRequestData(projectInstance, new[] { "GenerateRunSettingsFile" }));
 
-        return submission.OverallResult == BuildResultCode.Success;
+            return submission.OverallResult == BuildResultCode.Success;
+        }
+        finally
+        {
+            buildManager.EndBuild();
+        }
     }
 
     public string? GenerateIlcResponseFile(string testProject, string operatingSystem, string architecture, string configuration)
     {
-        var projectInstance = buildManager.GetProjectInstanceForBuild(
-            projectCollection.LoadProject(testProject, new Dictionary<string, string>
-            {
-                { "TargetOS", operatingSystem },
-                { "TargetArchitecture", architecture },
-                { "Configuration", configuration },
-                { "TestBuildMode", "nativeaot" },
-                { "IlcDynamicBuildPropertyDependencies", "_ComputeResolvedCopyLocalPublishAssets" }
-            },
-            projectCollection.DefaultToolsVersion));
-        var submission = buildManager.BuildRequest(new BuildRequestData(projectInstance, new[] { "Build", "GetCopyToPublishDirectoryItems", "_ComputeAssembliesToCompileToNative", "WriteIlcRspFileForCompilation" }));
-
-        if (submission.OverallResult != BuildResultCode.Success)
+        buildManager.BeginBuild(new BuildParameters(projectCollection)
         {
-            return null;
-        }
+            LogTaskInputs = true,
+            LogInitialPropertiesAndItems = true
+        });
+        try
+        {
+            var projectInstance = buildManager.GetProjectInstanceForBuild(
+                projectCollection.LoadProject(testProject, new Dictionary<string, string>
+                {
+                    { "TargetOS", operatingSystem },
+                    { "TargetArchitecture", architecture },
+                    { "Configuration", configuration },
+                    { "TestBuildMode", "nativeaot" },
+                    { "IlcDynamicBuildPropertyDependencies", "_ComputeResolvedCopyLocalPublishAssets" }
+                },
+                projectCollection.DefaultToolsVersion));
+            var submission = buildManager.BuildRequest(new BuildRequestData(projectInstance, new[] { "Build", "GetCopyToPublishDirectoryItems", "_ComputeAssembliesToCompileToNative", "WriteIlcRspFileForCompilation" }));
 
-        return submission.ResultsByTarget["WriteIlcRspFileForCompilation"].Items[0].ItemSpec;
+            if (submission.OverallResult != BuildResultCode.Success)
+            {
+                return null;
+            }
+
+            return submission.ResultsByTarget["WriteIlcRspFileForCompilation"].Items[0].ItemSpec;
+        }
+        finally
+        {
+            buildManager.EndBuild();
+        }
     }
 
     public void Dispose()

--- a/src/userPrompts.ts
+++ b/src/userPrompts.ts
@@ -166,6 +166,15 @@ export async function promptUserForLibrariesTest(options: { workspace: vscode.Ur
 	return result.originalData;
 }
 
+async function getAllRuntimeTestProjects(workspaceFolder: vscode.Uri) {
+	const testPathRoot = path.join(workspaceFolder.fsPath, 'src', 'tests');
+	return await promisify(glob)('**/*.*proj', { cwd: testPathRoot });
+}
+
+export async function promptUserForRuntimeTestProject(options: { workspace: vscode.Uri }) {
+	return await promptQuickPick(await getAllRuntimeTestProjects(options.workspace), { title: 'Select a runtime test project' });
+}
+
 function createQuickPickItems<T, TAdditionalProperties>(values: T[], factory: (value: T) => vscode.QuickPickItem & TAdditionalProperties, defaultValue?: T) {
 	let defaultQuickPick: vscode.QuickPickItem | undefined = undefined;
 	let quickPickItems = values.map(item => {


### PR DESCRIPTION
Fixes #6.

Getting a binlog still doesn't work, but this does correctly execute ILC.